### PR TITLE
Move GitHub access token to the header of the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Resolve deprecation of access token in query by GitHub
+
 ## 0.5.0
 
 * Implement AWS CodeBuild search of related builds

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ The parameter is expected to contain a json string with projects and builds info
 
 ## TODO
 
+- [ ] Move GitHub authentication to [OAuth with localhost redirects](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#localhost-redirect-urls)
 - [ ] Dependencies lock
-- [x] Allow to deploy from a branch, not only PR
 - [ ] Permit rerequest/overwrite github token
 - [ ] Permit multiple build runs in one command run
 - [ ] Add slack notifications

--- a/github/list.go
+++ b/github/list.go
@@ -42,9 +42,7 @@ func ListRequest(url string) (req *http.Request, err error) {
 		return nil, err
 	}
 
-	q := req.URL.Query()
-	q.Add("access_token", viper.GetString(githubTokenConfigName))
-	req.URL.RawQuery = q.Encode()
+	req.Header.Add("Authorization", "token "+viper.GetString(githubTokenConfigName))
 	return
 }
 

--- a/what/version.go
+++ b/what/version.go
@@ -3,7 +3,7 @@ package what
 import "fmt"
 
 // Version string assigned by LDFLAGS on build time
-var Version = "0.5.0"
+var Version = "0.5.1"
 
 // PrintVersion outputs tool version
 func PrintVersion() {


### PR DESCRIPTION
Users of the tool started receiving emails quoting [GitHub blog post](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters) on deprecation of access token in queries.

Move token to the header. The flow of authentication will need to change.